### PR TITLE
Update index.js so that module can be require()'d from an outside directory without error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var fs = require("fs"),
+    path = require("path"),
     cal = require("./calendar"),
     Calendar = cal.Calendar,
     cache = { };
@@ -7,11 +8,11 @@ exports.Calendar = Calendar;
 
 exports.calendar = function(name) {
     if (cache[name]) return cache[name];
-    else cache[name] = new Calendar(name, require("./locales/" + name));
+    else cache[name] = new Calendar(name, require(path.join(__dirname,"locales",name)));
     return cache[name];
 };
 
-exports.locales = fs.readdirSync("./locales").filter(/.*js/).map(function(file) {
+exports.locales = fs.readdirSync(path.join(__dirname,"locales")).filter(/.*js/).map(function(file) {
     var name = file.replace(".js", "");
     exports[name] = cache[name] = exports.calendar(name);
     return name;


### PR DESCRIPTION
When I would `require('fincal')` I would get ENOENT:

fs.js:951
  return binding.readdir(pathModule._makeLong(path), options.encoding);
                 ^

Error: ENOENT: no such file or directory, scandir './locales'
    at Error (native)
    at Object.fs.readdirSync (fs.js:951:18)
    at Object.<anonymous> (/home/hurricane/projects/trade/node_modules/fincal/index.js:14:22)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.require (module.js:468:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/home/hurricane/projects/trade/index.js:6:14)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)

I fixed this by making index.js look for the locales folder relative to its self by using `__dirname`.

Have I missed anything here? Are there any code formatting issues that you'd like fixed?

Cheers
