### PR TITLE
Add NYSE "holiday" on 2018-12-05

### DIFF
--- a/locales/new_york.js
+++ b/locales/new_york.js
@@ -78,7 +78,7 @@ exports.holidays = {
         July: [ 4 ],
         September: [ 3 ],
         November: [ 22 ],
-        December: [ 25 ]
+        December: [ 5, 25 ]
     },
     2019: {
         January: [ 1, 21 ],


### PR DESCRIPTION
Both [NYSE] and [NASDAQ] were closed on December 5 for the National Day of Mourning for President George H. W. Bush.

I'm not sure if the term "Market Holiday" is appropriate ([NY Times] and [Kiplinger] did use that term, NYSE did not), but since fincal doesn't have a notion of non-holiday market closures, this commit adds it to `.holidays`.

Thanks for considering,
Kevin

[Kiplinger]: https://www.kiplinger.com/article/investing/T038-C000-S001-is-the-stock-market-closed-for-president-bush.html
[NASDAQ]: https://www.nasdaq.com/article/is-the-stock-market-closed-for-president-bushs-funeral-cm1064501
[NY Times]: https://markets.on.nytimes.com/research/markets/holidays/holidays.asp
[NYSE]: https://www.nyse.com/trader-update/history#110000115869